### PR TITLE
create `malakal` folder for database file if missing

### DIFF
--- a/src/backend/indexed_local_dir.rs
+++ b/src/backend/indexed_local_dir.rs
@@ -1,7 +1,9 @@
 use chrono::{Timelike, Utc};
 use rusqlite::{params, Connection};
 use std::time::Duration;
-use std::{cell::RefCell, fs::create_dir_all, fs::Metadata, path::Path, time::Instant};
+use std::{
+  cell::RefCell, fs::create_dir_all, fs::Metadata, path::Path, time::Instant,
+};
 
 use crate::util::DateTime;
 use crate::{
@@ -26,8 +28,8 @@ struct ICSFileEntry {
 
 impl IndexedLocalDir {
   pub fn new<P: AsRef<Path>>(backend: LocalDir, index_path: P) -> Result<Self> {
-    if !index_path.try_exists()? {
-      create_dir_all(index_path.parent().unwrap())?;
+    if !index_path.as_ref().try_exists()? {
+      create_dir_all(index_path.as_ref().parent().unwrap())?;
     }
 
     let conn = Connection::open(index_path)?;

--- a/src/backend/indexed_local_dir.rs
+++ b/src/backend/indexed_local_dir.rs
@@ -1,7 +1,7 @@
 use chrono::{Timelike, Utc};
 use rusqlite::{params, Connection};
 use std::time::Duration;
-use std::{cell::RefCell, fs::Metadata, path::Path, time::Instant};
+use std::{cell::RefCell, fs::create_dir_all, fs::Metadata, path::Path, time::Instant};
 
 use crate::util::DateTime;
 use crate::{
@@ -26,6 +26,10 @@ struct ICSFileEntry {
 
 impl IndexedLocalDir {
   pub fn new<P: AsRef<Path>>(backend: LocalDir, index_path: P) -> Result<Self> {
+    if !index_path.try_exists()? {
+      create_dir_all(index_path.parent().unwrap())?;
+    }
+
     let conn = Connection::open(index_path)?;
     conn.pragma_update(None, "journal_mode", "WAL")?;
     conn.pragma_update(None, "temp_store", "memory")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::str::FromStr;
 
 use anyhow::Context;
@@ -46,10 +45,6 @@ fn main() -> anyhow::Result<()> {
     path.push(format!("{APP_NAME}/{APP_NAME}.db"));
     path
   };
-
-  if fs::metadata(&db_path).is_err() {
-    fs::create_dir_all(db_path.parent().unwrap())?;
-  }
 
   let backend = backend::IndexedLocalDir::new(local_backend, db_path)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::str::FromStr;
 
 use anyhow::Context;
@@ -45,6 +46,11 @@ fn main() -> anyhow::Result<()> {
     path.push(format!("{APP_NAME}/{APP_NAME}.db"));
     path
   };
+
+  if fs::metadata(&db_path).is_err() {
+    fs::create_dir_all(db_path.parent().unwrap())?;
+  }
+
   let backend = backend::IndexedLocalDir::new(local_backend, db_path)?;
 
   let mut app = app::App::new(&config, 3, timezone, backend)?;


### PR DESCRIPTION
When I tried to start `malakal`, a `malakal` folder didn't yet exist in my data directory, so the sqlite database wasn't able to connect. This code checks on startup whether that folder exists and creates it if not.